### PR TITLE
Update .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,11 +3,10 @@
     "transform-object-rest-spread"
   ],
   "presets": [
-    "es2015",
     [
       "env", {
         "targets": {
-          "node": 6   
+          "node": "current"
         }
       }
     ]


### PR DESCRIPTION
No need in `babel-preset-es2015`. 
All magic will be done by `babel-preset-env`.

Also changed pinned `6 version` on `current` user node version, for using less transpile rules.